### PR TITLE
add browserify compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+node_modules
+npm-debug.log

--- a/underscore.nest.js
+++ b/underscore.nest.js
@@ -4,7 +4,16 @@
 * Copyright (c) 2012 Irene Ros;
 * Underscore.Nest is freely distributable under the MIT license.
 */
-(function(global, _) {
+(function(global) {
+
+  var _ = global._;
+
+  if(_ === undefined) {
+    if (typeof require !== 'undefined') {
+      _ = require('underscore');
+    }
+  }
+
 
   var nester = global.nest = {};
 
@@ -100,4 +109,5 @@
     global._.mixin(nester);
   }
 
-}(this, _));
+}(this));
+


### PR DESCRIPTION
Thanks for the library!

This PR eases use with browserify. If there is a global underscore object available it will use that, but otherwise will attempt to `require()` underscore. This works in both a browserify and node.js environment.
